### PR TITLE
Fix: Insert after product properties rather than replacing them

### DIFF
--- a/app/overrides/add_social_buttons_to_produts.rb
+++ b/app/overrides/add_social_buttons_to_produts.rb
@@ -1,4 +1,4 @@
 Deface::Override.new(:virtual_path => 'spree/products/show',
                      :name => 'add_social_buttons_to_products_show',
-                     :replace => "[data-hook='product_properties']",
+                     :insert_after => "[data-hook='product_properties']",
                      :partial => 'spree/shared/social_buttons')


### PR DESCRIPTION
I was just installing the spree_social_products extension in addition to the spree_reviews extension and wondered why the reviews didn't show up anymore. The reason is that one of spree_social_products' overrides _replaces the product_properties section rather than inserting after it_. IMO extensions should never (or hardly ever) replace existing sections but instead prepend/append themselves properly. This pull request fixes the issue.
