### PR TITLE
improve tumblr share button: add name & description

### DIFF
--- a/app/assets/stylesheets/store/spree_social_products.css
+++ b/app/assets/stylesheets/store/spree_social_products.css
@@ -26,3 +26,11 @@
 .reddit img {
   padding-top: 3px;
 }
+.tumblr-share {
+  display:inline-block;
+  text-indent:-9999px;
+  overflow:hidden;
+  width:81px;
+  height:20px;
+  background:url('http://platform.tumblr.com/v1/share_1.png') top left no-repeat transparent;
+}

--- a/app/views/spree/social/_tumblr.html.erb
+++ b/app/views/spree/social/_tumblr.html.erb
@@ -1,1 +1,5 @@
-<a href="http://www.tumblr.com/share" title="Share on Tumblr" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('http://platform.tumblr.com/v1/share_1.png') top left no-repeat transparent;">Share on Tumblr</a>
+<%= link_to 'http://www.tumblr.com/share/link?' + {url: spree.product_url(@product), name: @product.name, description: @product.description}.to_param, title: 'Share on Tumblr', class: 'tumblr-share' do %>
+  Share on Tumblr
+<% end %>
+
+<script type="text/javascript" src="http://platform.tumblr.com/v1/share.js"></script>


### PR DESCRIPTION
- Share uses title and description of product
- Opens in new window when javascript enabled
