### PR TITLE
Use admin/spree_backend.css

### DIFF
--- a/app/assets/stylesheets/admin/spree_social_products.css
+++ b/app/assets/stylesheets/admin/spree_social_products.css
@@ -1,5 +1,5 @@
 /*
- *= require admin/spree_frontend
+ *= require admin/spree_backend
 */
 
 ul.social_list li {


### PR DESCRIPTION
admin/spree_frontend.css was removed by spree commit:
56d94de4896198464d3cfb487f8b4b3d7c84d81d

app/assets/stylesheets/admin/spree_social_products.css: Update to reflect the change
