### PR TITLE
showing configurations sidebar on social sharing settings area

### DIFF
--- a/app/views/spree/admin/social/edit.html.erb
+++ b/app/views/spree/admin/social/edit.html.erb
@@ -1,3 +1,5 @@
+<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+
 <h1><%= t("social_sharing_buttons") %></h1>
 <div class="social_sharing_form">
   <p><%= t("social_sharing_settings_description") %></p>


### PR DESCRIPTION
Hi,

When I installed this extension I noticed that the **Social Sharing Settings** on the admin area had no sidebar.

The `edit.html.erb` template is now rendering the `configuration_menu` partial like the other configuration pages.

It is looking like this now:

![screen shot 2014-04-19 at 11 47 59 pm](https://cloud.githubusercontent.com/assets/1538066/2749919/3c43c428-c836-11e3-950a-c40ed3c2b5e7.png)
