### PR TITLE
Depend on spree_core 2.3.0

### DIFF
--- a/spree_social_products.gemspec
+++ b/spree_social_products.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2.0.beta'
+  s.add_dependency 'spree_core', '~> 2.3.0'
 
   s.add_development_dependency 'capybara', '1.0.1'
   s.add_development_dependency 'factory_girl', '~> 2.6.4'


### PR DESCRIPTION
Hi , facebook like not displayed .  
![2015-04-06 21 34 21](https://cloud.githubusercontent.com/assets/4145211/7009783/60e01758-dca5-11e4-8a59-836240cf8332.png)

When I point Spree::Config.facebook_app_id = 'YOUR_FACEBOOK_APP_ID'

![2015-04-06 21 39 42](https://cloud.githubusercontent.com/assets/4145211/7009825/adc1b2b6-dca5-11e4-966f-6bbd8170fe3f.png)

my email andrei.richi@gmail.com
Thanks
