### PR TITLE
Add twitter card for products

### DIFF
--- a/app/views/spree/admin/social_settings/edit.html.erb
+++ b/app/views/spree/admin/social_settings/edit.html.erb
@@ -69,7 +69,19 @@
             </div>
 
           </fieldset>
+        </div>
 
+        <div class="col-md-6" data-hook="twitter">
+          <fieldset>
+            <legend><%= Spree.t(:twitter_settings, scope: :social) %></legend>
+
+            <div id="twitter_options">
+              <div class="form-group">
+                <%= label_tag :twitter_id, Spree.t(:twitter_id, scope: [:social, :preferences]) %>
+                <%= text_field_tag :twitter_id, Spree::Social::Config[:twitter_id], class: 'form-control' %>
+              </div>
+            </div>
+          </fieldset>
         </div>
       </div>
 

--- a/app/views/spree/social/_twitter.html.erb
+++ b/app/views/spree/social/_twitter.html.erb
@@ -1,3 +1,17 @@
+<% content_for :head do %>
+  <meta property="twitter:card" content="product" />
+  <% unless Spree::Social::Config.preferred_twitter_id.nil? %>
+    <meta property="twitter:site" content="<%= Spree::Social::Config.preferred_twitter_id %>" />
+  <% end %>
+  <meta property="twitter:title" content="<%= @product.name %>" />
+  <meta property="twitter:description" content="<%= @product.description %>" />
+  <meta property="twitter:image" content="<%= absolute_image_url(@product.images.first.attachment.url) %>" />
+  <% unless @product.price.nil? %>
+    <meta property="twitter:label1" content="<%= Spree.t(:price) %>" />
+    <meta property="twitter:data1" content="<%= @product.price_in(current_currency).money %>" />
+  <% end %>
+<% end %>
+
 <a href="https://twitter.com/share" class="twitter-share-button" data-count="none">
   <%= Spree.t(:tweet, scope: [:social, :buttons]) %>
 </a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
       settings: Social Sharing Settings
       service_settings: Service Settings
       facebook_settings: Facebook Settings
+      twitter_settings: Twitter Settings
       buttons:
         delicious: Delicious
         submit_to_reddit: Submit to Reddit
@@ -21,3 +22,4 @@ en:
         facebook_verb_to_display: Verb to Display
         facebook_color_scheme: Color Scheme
         facebook_send_button: Share button
+        twitter_id: Twitter ID

--- a/lib/spree/social_setting.rb
+++ b/lib/spree/social_setting.rb
@@ -13,6 +13,7 @@ module Spree
     preference :facebook_verb_to_display, :string,  default: 'like'
     preference :facebook_color_scheme,    :string,  default: 'light'
     preference :facebook_send_button,     :boolean, default: false
+    preference :twitter_id,               :string
 
     def facebook_layouts
       %w(standard button_count box_count button)

--- a/spec/controllers/spree/admin/social_settings_controller_spec.rb
+++ b/spec/controllers/spree/admin/social_settings_controller_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Spree::Admin::SocialSettingsController, type: :controller do
             facebook_show_faces: true
             facebook_verb_to_display: recommend
             facebook_color_scheme: dark
-            facebook_send_button: false' do
+            facebook_send_button: false
+            twitter_id' do
       subject { Spree::Social::Config }
 
       it 'sets twitter_button to false' do
@@ -86,6 +87,11 @@ RSpec.describe Spree::Admin::SocialSettingsController, type: :controller do
       it 'sets facebook_send_button to false' do
         spree_put :update, preferences: { facebook_send_button: false }
         expect(subject.preferred_facebook_send_button).to be(false)
+      end
+
+      it 'sets twitter_id to "123"' do
+        spree_put :update, preferences: { twitter_id: '123' }
+        expect(subject.preferred_twitter_id).to eq('123')
       end
     end
   end


### PR DESCRIPTION
Add meta tags to create the twitter card for produtcs.

Reference:
https://dev.twitter.com/cards/types/product